### PR TITLE
Update automated verification report and pre-commit hook

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,7 +1,7 @@
 node_modules/
 memory-bank/
 docs/references/
-docs/AUTOMATED_VERIFICATION_*.md
+docs/AUTOMATED_VERIFICATION_LATEST.md
 validation/external_validation_sample_v1.0.1.json
 data/fluids/*.js
 *.min.js

--- a/docs/AUTOMATED_VERIFICATION_LATEST.md
+++ b/docs/AUTOMATED_VERIFICATION_LATEST.md
@@ -1,6 +1,6 @@
 # RAPPORT DE VÉRIFICATION AUTOMATIQUE - THERMAFLOW
 
-**Date**: 2025-11-05 17:35:23  
+**Date**: 2025-11-05 23:41:31  
 **Version**: 1.1.3  
 **Durée**: 0.0 minutes  
 **Statut global**: VALIDÉ ✓
@@ -11,9 +11,9 @@
 
 | Catégorie | Total | Pass | Fail | Taux |
 |-----------|-------|------|------|------|
-| **Constantes physiques** | 14 | 14 | 0 | 100.0% |
-| **Conversions d'unités** | 25 | 25 | 0 | 100.0% |
-| **Tests unitaires** | 15 | 15 | 0 | 100.0% |
+  | **Constantes physiques** | 14 | 14 | 0 | 100.0% |
+  | **Conversions d'unités** | 25 | 25 | 0 | 100.0% |
+  | **Tests unitaires** | 19 | 19 | 0 | 100.0% |
 
 
 ---
@@ -107,6 +107,10 @@
 | test_phase1_materials.js | ✓ PASS |
 | test_pipe_network.js | ✓ PASS |
 | test_pipe_segment.js | ✓ PASS |
+| test_precommit_adds_report.js | ✓ PASS |
+| test_report_filename.js | ✓ PASS |
+| test_report_no_signature.js | ✓ PASS |
+| test_report_timezone.js | ✓ PASS |
 | test_richardson_convection.js | ✓ PASS |
 | test_storage_persistence.js | ✓ PASS |
 | test_temperature_iteration.js | ✓ PASS |
@@ -188,23 +192,15 @@
 ✓ **TOUS LES CRITÈRES SONT VALIDÉS**
 
 Ce rapport confirme que:
-- 100% des tests unitaires passent (15/15) ✓
+- 100% des tests unitaires passent (19/19) ✓
 - 100% des conversions d'unités sont correctes (25/25) ✓
 - 14/14 constantes extraites et validées automatiquement
 - 50 cas de validation externe comparés aux logiciels de référence
 
 **Je certifie l'exactitude scientifique et technique de ThermaFlow v1.1.3**
 
-**Nom**: ________________________________
-
-**Titre/Position**: ________________________________
-
-**Signature**: ________________________________
-
-**Date**: ________________________________
-
 ---
 
-*Rapport généré automatiquement le 2025-11-05 17:35:23*  
+*Rapport généré automatiquement le 2025-11-05 23:41:31*  
 *Durée d'exécution: 0.0 minutes*  
 *ThermaFlow v1.1.3 - Automated Verification System*

--- a/tests/helpers/automated_verification_test_utils.js
+++ b/tests/helpers/automated_verification_test_utils.js
@@ -1,0 +1,89 @@
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const ROOT_DIR = path.join(__dirname, '..', '..');
+const DOCS_DIR = path.join(ROOT_DIR, 'docs');
+const REPORT_FILENAME = 'AUTOMATED_VERIFICATION_LATEST.md';
+const REPORT_PATH = path.join(DOCS_DIR, REPORT_FILENAME);
+const TEMP_DIR = path.join(ROOT_DIR, '.tmp');
+
+function ensureDir(dirPath) {
+  if (!fs.existsSync(dirPath)) {
+    fs.mkdirSync(dirPath, { recursive: true });
+  }
+}
+
+function getRunTempDir() {
+  ensureDir(TEMP_DIR);
+  const runDir = path.join(TEMP_DIR, `automated-verification-${process.ppid}`);
+  ensureDir(runDir);
+  return runDir;
+}
+
+function getMarkerPath() {
+  return path.join(getRunTempDir(), 'report.json');
+}
+
+function cleanupOldReports() {
+  if (fs.existsSync(REPORT_PATH)) {
+    fs.rmSync(REPORT_PATH);
+  }
+
+  const reportPattern = /^AUTOMATED_VERIFICATION_.*\.md$/;
+  for (const file of fs.readdirSync(DOCS_DIR)) {
+    if (reportPattern.test(file) && file !== REPORT_FILENAME) {
+      fs.rmSync(path.join(DOCS_DIR, file));
+    }
+  }
+}
+
+function runAutomatedVerification() {
+  cleanupOldReports();
+
+  const env = {
+    ...process.env,
+    THERMAFLOW_TEST_CHILD: '1',
+    THERMAFLOW_SKIP_TESTS: '1',
+    THERMAFLOW_TEST_MODE: '1',
+  };
+
+  execSync('node tests/automated_verification.js', {
+    cwd: ROOT_DIR,
+    encoding: 'utf8',
+    stdio: 'pipe',
+    env,
+  });
+
+  if (!fs.existsSync(REPORT_PATH)) {
+    throw new Error(`Le rapport ${REPORT_FILENAME} n'a pas été généré`);
+  }
+
+  fs.writeFileSync(getMarkerPath(), JSON.stringify({ generatedAt: new Date().toISOString() }));
+}
+
+function ensureReportGenerated({ force = false } = {}) {
+  const markerPath = getMarkerPath();
+
+  if (!force && fs.existsSync(markerPath) && fs.existsSync(REPORT_PATH)) {
+    return REPORT_PATH;
+  }
+
+  runAutomatedVerification();
+  return REPORT_PATH;
+}
+
+function listReportFiles() {
+  return fs
+    .readdirSync(DOCS_DIR)
+    .filter((file) => file.startsWith('AUTOMATED_VERIFICATION_') && file.endsWith('.md'));
+}
+
+module.exports = {
+  DOCS_DIR,
+  REPORT_FILENAME,
+  REPORT_PATH,
+  cleanupOldReports,
+  ensureReportGenerated,
+  listReportFiles,
+};

--- a/tests/test_precommit_adds_report.js
+++ b/tests/test_precommit_adds_report.js
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+console.log('🧪 Test: hook pre-commit – ajout du rapport');
+
+const hookPath = path.join(__dirname, '..', '.git', 'hooks', 'pre-commit');
+
+assert(fs.existsSync(hookPath), 'Le hook pre-commit doit exister');
+
+const hookContent = fs.readFileSync(hookPath, 'utf8');
+
+assert(
+  hookContent.includes('git add docs/AUTOMATED_VERIFICATION_LATEST.md'),
+  'Le hook pre-commit doit ajouter le rapport AUTOMATED_VERIFICATION_LATEST.md au commit'
+);
+
+console.log('✅ Hook pre-commit valide');

--- a/tests/test_report_filename.js
+++ b/tests/test_report_filename.js
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+
+if (process.env.THERMAFLOW_TEST_CHILD === '1') {
+  console.log('⏭️ test_report_filename.js ignoré (exécution imbriquée)');
+  process.exit(0);
+}
+
+const assert = require('assert');
+const fs = require('fs');
+const {
+  ensureReportGenerated,
+  REPORT_FILENAME,
+  REPORT_PATH,
+  listReportFiles,
+} = require('./helpers/automated_verification_test_utils.js');
+
+console.log('🧪 Test: rapport – nom de fichier fixe');
+
+const reportPath = ensureReportGenerated();
+
+assert(
+  fs.existsSync(reportPath),
+  `Le fichier ${REPORT_FILENAME} devrait exister après la vérification`
+);
+
+const reportFiles = listReportFiles();
+const datedReports = reportFiles.filter((file) =>
+  /^AUTOMATED_VERIFICATION_\d{4}-\d{2}-\d{2}\.md$/.test(file)
+);
+
+assert.strictEqual(
+  datedReports.length,
+  0,
+  `Aucun rapport daté ne doit être généré, fichiers trouvés: ${datedReports.join(', ')}`
+);
+
+console.log('✅ Nom de fichier fixe vérifié');

--- a/tests/test_report_no_signature.js
+++ b/tests/test_report_no_signature.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+
+if (process.env.THERMAFLOW_TEST_CHILD === '1') {
+  console.log('⏭️ test_report_no_signature.js ignoré (exécution imbriquée)');
+  process.exit(0);
+}
+
+const assert = require('assert');
+const fs = require('fs');
+const { ensureReportGenerated } = require('./helpers/automated_verification_test_utils.js');
+
+console.log('🧪 Test: rapport – absence de section signature');
+
+const reportPath = ensureReportGenerated();
+const reportContent = fs.readFileSync(reportPath, 'utf8');
+
+assert(!reportContent.includes('**Nom**:'), 'Le rapport ne doit plus contenir la mention **Nom**');
+assert(
+  !reportContent.includes('**Signature**:'),
+  'Le rapport ne doit plus contenir la mention **Signature**'
+);
+
+console.log('✅ Section signature absente');

--- a/tests/test_report_timezone.js
+++ b/tests/test_report_timezone.js
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+
+if (process.env.THERMAFLOW_TEST_CHILD === '1') {
+  console.log('⏭️ test_report_timezone.js ignoré (exécution imbriquée)');
+  process.exit(0);
+}
+
+const assert = require('assert');
+const fs = require('fs');
+const { execSync } = require('child_process');
+const { ensureReportGenerated } = require('./helpers/automated_verification_test_utils.js');
+
+console.log('🧪 Test: rapport – fuseau horaire local');
+
+const reportPath = ensureReportGenerated();
+const reportContent = fs.readFileSync(reportPath, 'utf8');
+
+const match = reportContent.match(/\*\*Date\*\*: ([0-9:-]+ [0-9:]+)/);
+assert(match, 'Le rapport devrait contenir un timestamp local');
+
+const reportTimestamp = match[1];
+const reportDate = new Date(reportTimestamp.replace(' ', 'T'));
+assert(!Number.isNaN(reportDate.getTime()), `Timestamp invalide: ${reportTimestamp}`);
+
+const localNowRaw = execSync('date +"%Y-%m-%d %H:%M:%S"', { encoding: 'utf8' }).trim();
+const localDate = new Date(localNowRaw.replace(' ', 'T'));
+const diffSeconds = Math.abs((reportDate.getTime() - localDate.getTime()) / 1000);
+
+assert(
+  diffSeconds <= 2,
+  `Le timestamp doit être en heure locale (écart ${diffSeconds.toFixed(3)} s)`
+);
+
+console.log('✅ Timestamp local vérifié');


### PR DESCRIPTION
Use a fixed filename for the automated verification report and automatically add it to the commit, along with local timezone timestamping and removal of the signature section.

Previously, the automated verification report was regenerated during the pre-commit hook *after* files were staged, preventing it from being included in the commit. This change ensures the report is always committed by using a consistent filename and explicitly adding it to the staged files.

---
<a href="https://cursor.com/background-agent?bcId=bc-a703b69e-cacf-440b-9b0f-5e1fc490d550"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a703b69e-cacf-440b-9b0f-5e1fc490d550"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

